### PR TITLE
Add rockspec.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sockproc"]
+	path = sockproc
+	url = https://github.com/juce/sockproc.git

--- a/lua-resty-shell-scm-1.rockspec
+++ b/lua-resty-shell-scm-1.rockspec
@@ -17,6 +17,7 @@ build = {
   type          = "command",
   build_command = [[
        git submodule init \
+    && git submodule update \
     && cd sockproc \
     && git checkout master \
     && git pull \

--- a/lua-resty-shell-scm-1.rockspec
+++ b/lua-resty-shell-scm-1.rockspec
@@ -14,8 +14,20 @@ dependencies = {
 }
 
 build = {
-  type    = "builtin",
-  modules = {
-    ["resty.shell"] = "lib/resty/shell.lua",
+  type          = "command",
+  build_command = [[
+       git submodule init \
+    && cd sockproc \
+    && git checkout master \
+    && git pull \
+    && make
+  ]],
+  install = {
+    lua = {
+      ["resty.shell"] = "lib/resty/shell.lua",
+    },
+    bin = {
+      ["sockproc"] = "sockproc/sockproc",
+    }
   },
 }

--- a/lua-resty-shell-scm-1.rockspec
+++ b/lua-resty-shell-scm-1.rockspec
@@ -1,0 +1,21 @@
+package = "lua-resty-shell"
+version = "scm-1"
+source  = {
+  url = "git+https://github.com/juce/lua-resty-shell.git",
+}
+description = {
+  summary  = "Tiny subprocess/shell library to use with OpenResty application server.",
+  detailed = "",
+  homepage = "https://github.com/juce/lua-resty-shell",
+  license  = "MIT",
+}
+dependencies = {
+  "lua >= 5.1",
+}
+
+build = {
+  type    = "builtin",
+  modules = {
+    ["resty.shell"] = "lib/resty/shell.lua",
+  },
+}


### PR DESCRIPTION
Adding a rockspec allows users to install `lua-resty-shell` easily. The rockspec automatically pulls the `master` of [sockproc](https://github.com/juce/sockproc), builds it and installs it.
If you accept this pull request, you should also do a release on https://luarocks.org.